### PR TITLE
COMP: Fix building with CMake < 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,9 @@ foreach(p
   endif()
 endforeach()
 
-cmake_policy(SET CMP0042 OLD)
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 OLD)
+endif()
 
 project(ITK)
 


### PR DESCRIPTION
Policy CMP0042 was introduced in CMake 3.0. This commit fixes the following
error when building with earlier versions of CMake:

    CMake Error at CMakeLists.txt:15 (cmake_policy):
      Policy "CMP0042" is not known to this version of CMake.