### PR TITLE
COMP: Simplify ITKVideoBridgeOpenCV dependency

### DIFF
--- a/Modules/Video/BridgeOpenCV/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.9)
+if(NOT ITK_SOURCE_DIR)
+  include(itk-module-init.cmake)
+endif()
 project(ITKVideoBridgeOpenCV)
 
 set(ITKVideoBridgeOpenCV_LIBRARIES ITKVideoBridgeOpenCV)

--- a/Modules/Video/BridgeOpenCV/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 2.8.9)
 project(ITKVideoBridgeOpenCV)
 
 set(ITKVideoBridgeOpenCV_LIBRARIES ITKVideoBridgeOpenCV)
@@ -5,4 +6,10 @@ set(ITKVideoBridgeOpenCV_LIBRARIES ITKVideoBridgeOpenCV)
 set(ITKVideoBridgeOpenCV_SYSTEM_INCLUDE_DIRS ${OpenCV_INCLUDE_DIRS})
 set(ITKVideoBridgeOpenCV_SYSTEM_LIBRARY_DIRS ${OpenCV_LIB_DIR})
 
-itk_module_impl()
+if(NOT ITK_SOURCE_DIR)
+ find_package(ITK REQUIRED)
+ list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+ include(ITKModuleExternal)
+else()
+ itk_module_impl()
+endif()

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVImageBridge.hxx
@@ -258,7 +258,7 @@ OpenCVImageBridge::ITKImageToCVMat(const TInputImageType* in, bool force3Channel
 {
   // Extra copy, but necessary to prevent memory leaks
   IplImage* temp = ITKImageToIplImage<TInputImageType>(in, force3Channels);
-  cv::Mat out(temp, true);
+  cv::Mat out = cv::cvarrToMat( temp, true );
   cvReleaseImage(&temp);
   return out;
 }

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.h
@@ -23,6 +23,10 @@
 #include "highgui.h"
 #include "itkVideoStream.h"
 
+#if CV_VERSION_MAJOR > 2
+#include "opencv2/videoio.hpp"
+#endif
+
 namespace itk
 {
 

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoCapture.hxx
@@ -181,7 +181,7 @@ bool OpenCVVideoCapture<TVideoStream>::retrieve(cv::Mat& image, int itkNotUsed(c
 
   // Pass off to the Mat
   image.create(size[0], size[1], matrixType);
-  image = iplImg;
+  image = cv::cvarrToMat(iplImg, true);
 
   // Return success
   return true;

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIO.h
@@ -21,7 +21,7 @@
 #include "itkVideoIOBase.h"
 #include "cv.h"
 #include "highgui.h"
-
+#include "ITKVideoBridgeOpenCVExport.h"
 
 namespace itk
 {
@@ -31,7 +31,7 @@ namespace itk
  *
  * \ingroup ITKVideoBridgeOpenCV
  */
-class OpenCVVideoIO:public VideoIOBase
+class ITKVideoBridgeOpenCV_EXPORT OpenCVVideoIO : public VideoIOBase
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIOFactory.h
+++ b/Modules/Video/BridgeOpenCV/include/itkOpenCVVideoIOFactory.h
@@ -20,6 +20,7 @@
 
 #include "itkObjectFactoryBase.h"
 #include "itkVideoIOBase.h"
+#include "ITKVideoBridgeOpenCVExport.h"
 
 namespace itk
 {
@@ -28,7 +29,7 @@ namespace itk
  *
  * \ingroup ITKVideoBridgeOpenCV
  */
-class OpenCVVideoIOFactory:public ObjectFactoryBase
+class ITKVideoBridgeOpenCV_EXPORT OpenCVVideoIOFactory: public ObjectFactoryBase
 {
 public:
   /** Standard class typedefs. */

--- a/Modules/Video/BridgeOpenCV/itk-module.cmake
+++ b/Modules/Video/BridgeOpenCV/itk-module.cmake
@@ -4,8 +4,7 @@ bridges for both image data and video data.")
 
 itk_module(ITKVideoBridgeOpenCV
   ENABLE_SHARED
-  COMPILE_DEPENDS
-    ITKVideoCore
+  DEPENDS
     ITKVideoIO
   TEST_DEPENDS
     ITKTestKernel

--- a/Modules/Video/BridgeOpenCV/src/CMakeLists.txt
+++ b/Modules/Video/BridgeOpenCV/src/CMakeLists.txt
@@ -5,5 +5,5 @@ itkOpenCVVideoIOFactory.cxx
 
 add_library(ITKVideoBridgeOpenCV ${ITKVideoBridgeOpenCV_SRC})
 itk_module_link_dependencies()
-target_link_libraries(ITKVideoBridgeOpenCV LINK_PUBLIC ITKVideoCore ITKVideoIO ${OpenCV_LIBS})
+target_link_libraries(ITKVideoBridgeOpenCV LINK_PUBLIC ${OpenCV_LIBS})
 itk_module_target(ITKVideoBridgeOpenCV)

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -24,6 +24,9 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
 
+#if CV_VERSION_MAJOR > 2
+#include "opencv2/opencv.hpp" // cv::imread
+#endif
 
 //-----------------------------------------------------------------------------
 // Convert the data in the IplImage to the templated type

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -20,9 +20,12 @@
 
 #include "itkOpenCVImageBridge.h"
 #include "itkImageFileReader.h"
-#include "itkTestingComparisonImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkOpenCVVideoIOFactory.h"
+
+#if CV_VERSION_MAJOR > 2
+#include "opencv2/opencv.hpp" // cv::imread
+#endif
 
 //-----------------------------------------------------------------------------
 // Compare RGBPixel Images
@@ -140,8 +143,6 @@ int itkOpenCVImageBridgeTestTemplatedRGB(char* argv0, char* argv1)
   typedef typename PixelType::ComponentType               ComponentType;
   typedef itk::Image< PixelType, Dimension >              ImageType;
   typedef itk::ImageFileReader<ImageType>                 ReaderType;
-  typedef itk::Testing::ComparisonImageFilter<ImageType, ImageType>
-                                                          DifferenceFilterType;
 
   //
   // Read the image directly

--- a/Modules/Video/IO/include/itkVideoIOBase.h
+++ b/Modules/Video/IO/include/itkVideoIOBase.h
@@ -20,6 +20,7 @@
 
 #include "itkImageIOBase.h"
 #include "itkExceptionObject.h"
+#include "ITKVideoIOExport.h"
 #include "vnl/vnl_vector.h"
 
 #include <string>
@@ -45,7 +46,7 @@ namespace itk
  *
  * \ingroup ITKVideoIO
  */
-class VideoIOBase : public ImageIOBase
+class ITKVideoIO_EXPORT VideoIOBase : public ImageIOBase
 {
 public:
   /** Standard class typedefs. */


### PR DESCRIPTION
When turning on the CMake flag to build the BridgeOpenCV module for the Slicer branch of ITK, compilation was failing. Comparison against the successfully building ITK trunk led to finding
a patch that was applied[1] to fix the dependency and missing library exports.
This patch results in the Slicer ITK compiling with this module enabled. 
This patch is a prerequisite to adding the OpenCV extension module to Slicer.

[1] https://github.com/InsightSoftwareConsortium/ITK/commit/412dd83a680cc024c12f971ec57f76881c7eab78