### PR TITLE
BUG: ITK-3553 fixes ImageOrientation issue in DCMTK reader

### DIFF
--- a/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
+++ b/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx
@@ -1102,17 +1102,21 @@ DCMTKFileReader
 
   dircos[0] = 1; dircos[1] = 0; dircos[2] = 0;
   dircos[3] = 0; dircos[4] = 1; dircos[5] = 0;
-  if((rval = this->GetElementDS(0x0020,0x0037,6,dircos,false)) != EXIT_SUCCESS)
+  // check toplevel ImageOrientationPatient (most common case)
+  if((rval = this->GetElementDS(0x0020,0x0037,6,dircos,false)) == EXIT_SUCCESS)
     {
-    rval = this->GetElementSQ(0x0020,0x9116,planeSeq,false);
-    if(rval == EXIT_SUCCESS)
-      {
-      rval = planeSeq.GetElementDS(0x0020,0x0037,6,dircos,false);
-      return rval;
-      }
+    return rval;
     }
-  //
-  // for multiframe Philips images
+  // look inside plane sequence at top level (probably not common)
+  rval = this->GetElementSQ(0x0020,0x9116,planeSeq,false);
+  if(rval == EXIT_SUCCESS)
+    {
+    rval = planeSeq.GetElementDS(0x0020,0x0037,6,dircos,false);
+    return rval;
+    }
+  // ImageOrientationPatient not at top level or toplevel plane sequence,
+  // so look in the shared and per-frame functional groups
+  // as standard for multiframe (e.g. Philips) images
   unsigned short candidateSequences[2] =
     {
       0x9229, // check for Shared Functional Group Sequence first


### PR DESCRIPTION
A previous reader [1] contained logic to look in two places for
image orientation.

Three years ago a new version [2] was introduced with a logic error.

Before, rval was 0 (success) when reading the regular
ImageOrientationPatient tag and that was returned.
In the new version rval is overwritten by the results of looking for
the per-frame or shared functional groups.

This was introduced when the code was generalized for enhance
multiframes [2].

[1] https://github.com/Kitware/ITK/blob/e081d837a4ae8c7c090456081fdd90610bbe7742/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx#L1078-L1119
[2] https://github.com/Kitware/ITK/blob/49de8835474d1e49c96cb9565b3c72c8f118b691/Modules/IO/DCMTK/src/itkDCMTKFileReader.cxx#L1096-L1146
[3] https://github.com/Kitware/ITK/commit/98cd612be6f60ec632dc97ac05a64025eb805dba