### PR TITLE
COMP: Fix Slicer vtkITK build on macOS

### DIFF
--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -776,7 +776,7 @@ compilers.
 
 #ifndef NDEBUG
 
-#  ifdef _POSIX_SOURCE
+#  ifdef __GLIBC__
 #    define itkAssertInDebugOrThrowInReleaseMacro(msg) __assert_fail(msg, __FILE__, __LINE__, __ASSERT_FUNCTION);
 #  else
 #    define itkAssertInDebugOrThrowInReleaseMacro(msg) itkGenericExceptionMacro(<< msg);


### PR DESCRIPTION
This commit addresses a Slicer macOS build error reported on Discourse
(see https://discourse.slicer.org/t/slicer-build-on-macos-monterey/21940)
and on GitHub (see comments on issue #5944).

The _POSIX_SOURCE preprocessor identifier is defined in several places
including by Python and several ITK ThirdParty modules. It looks like
this definition is causing unintended side effects when building vtkITK.

When itkMacro.h is #included in vtkITK, _POSIX_SOURCE causes conditional
inclusion of code using __assert_fail and __ASSERT_FUNCTION, which are
only defined on Linux and not on macOS. This results in a compile error.

This commit fixes the error by checking for the __linux preprocessor
identifier instead of __POSIX_SOURCE.