### PR TITLE
NRRD sequence 5D IO

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileReader.hxx
+++ b/Modules/IO/ImageBase/include/itkImageFileReader.hxx
@@ -181,7 +181,7 @@ ImageFileReader<TOutputImage, ConvertPixelTraits>::GenerateOutputInformation()
       axis = directionIO[i];
       for (unsigned int j = 0; j < TOutputImage::ImageDimension; ++j)
       {
-        if (j < numberOfDimensionsIO)
+        if (j < numberOfDimensionsIO && j < axis.size())
         {
           direction[j][i] = axis[j];
         }


### PR DESCRIPTION
I'm not sure yet how best to integrate these changes to ITK, but as I was working on top of the Slicer ITK fork, I'm starting the discussion here.

This PR aims to add support for reading/writing 5D NRRD files (sequence of vector volumes). See details in the commit message.

The major changes were approved, see this forum topic: https://discourse.itk.org/t/reading-in-vector-volume-from-nrrd-with-variable-scalar-component-count/7485
