### PR TITLE
Slicer v5.4.4 2025 06 11 f98d5fa fix build errors with testing enabled

### DIFF
--- a/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
+++ b/Modules/Compatibility/Deprecated/include/itkTreeIteratorBase.h
@@ -147,7 +147,7 @@ public:
   /** Remove a child.
    *
    * Removes its child nodes as well.
-   * /
+   */
   virtual bool
   RemoveChild(int number);
 

--- a/Modules/IO/XML/include/itkFileTools.h
+++ b/Modules/IO/XML/include/itkFileTools.h
@@ -19,6 +19,8 @@
 #ifndef itkFileTools_h
 #define itkFileTools_h
 
+#include "itkMacro.h"
+
 #include <string>
 
 namespace itk
@@ -46,8 +48,6 @@ public:
 // here comes the implementation
 
 #include "itksys/SystemTools.hxx"
-#include "itkMacro.h"
-
 namespace itk
 {
 


### PR DESCRIPTION
Some deprecated code that is still in Slicer's ITK caused build errors when ITK was build with testing mode enabled. These functions/classes are no longer in ITK upstream, therefore the fixes are only applicable to this branch.