### PR TITLE
ENH: Add namespace to ITK autoload symbol

### DIFF
--- a/Modules/Core/Common/include/itkFactoryTestLib.h
+++ b/Modules/Core/Common/include/itkFactoryTestLib.h
@@ -29,7 +29,7 @@
 extern "C"
 {
   ITK_ABI_EXPORT itk::ObjectFactoryBase *
-                 itkLoad();
+                 ITK_LOAD_FUNCTION_NAME();
 }
 
 #endif

--- a/Modules/Core/Common/src/itkNamespace.h.in
+++ b/Modules/Core/Common/src/itkNamespace.h.in
@@ -25,4 +25,9 @@
 #define itk ITK_NAMESPACE
 #endif
 
+// Defines the symbol name for the load function used by ITK's Object
+// Factory for dynamic loading of shared libraries.
+#define ITK_LOAD_FUNCTION_NAME ITK_NAMESPACE##Load
+
+
 #endif //itkNamespace_h

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -39,6 +39,11 @@
 #include <algorithm>
 #include <atomic>
 
+
+#define ITK_NAMESPACE_TO_STRING0(x) #x
+#define ITK_NAMESPACE_TO_STRING(x) ITK_NAMESPACE_TO_STRING0(x)
+#define ITK_LOAD_SYMBOL ITK_NAMESPACE_TO_STRING(ITK_LOAD_FUNCTION_NAME)
+
 namespace
 {
 /** \class OverrideInformation
@@ -407,7 +412,7 @@ ObjectFactoryBase::LoadLibrariesInPath(const char * path)
         /**
          * Look for the symbol itkLoad in the library
          */
-        auto loadfunction = (ITK_LOAD_FUNCTION)DynamicLoader::GetSymbolAddress(lib, "itkLoad");
+        auto loadfunction = (ITK_LOAD_FUNCTION)DynamicLoader::GetSymbolAddress(lib, ITK_LOAD_SYMBOL);
         /**
          * if the symbol is found call it to create the factory
          * from the library

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -178,7 +178,7 @@ private:
  */
 static ImportImageContainerFactory::Pointer staticImportImageContainerFactory;
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   staticImportImageContainerFactory = ImportImageContainerFactory::New();
   return staticImportImageContainerFactory;

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
@@ -31,12 +31,12 @@
 extern "C"
 {
   ITKIOImageBase_EXPORT itk::ObjectFactoryBase *
-                        itkLoad();
+                        ITK_LOAD_FUNCTION_NAME();
 }
 
 
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   static itk::FileFreeImageIOFactory::Pointer f = itk::FileFreeImageIOFactory::New();
   return f;


### PR DESCRIPTION
The ITK plugin system autoload libraries and checks for a defined symbol. Update this expected symbol to use the namespace. The load function is now defined as: ITK_LOAD_FUNCTION_NAME